### PR TITLE
Transformed main for readStudy

### DIFF
--- a/Singularity.def
+++ b/Singularity.def
@@ -29,7 +29,7 @@ From: python:3.13-slim
     pip install --no-cache-dir --root-user-action=ignore mock pluggy pytest
 
     # Run tests, failing the build if unsuccessful
-    python -m pytest --cache-clear
+    python -m pytest --cache-clear -vs
 
     # Remove test-only dependencies
     pip uninstall --no-cache-dir --root-user-action=ignore --yes mock pluggy pytest

--- a/hallmonitor/app.py
+++ b/hallmonitor/app.py
@@ -28,6 +28,9 @@ from hallmonitor.hmutils import (
     get_deviation_string,
     get_eeg_errors,
     get_expected_combination_rows,
+    get_joint_root_vars,
+    get_deviation_file,
+    get_no_data_file,
     get_expected_files,
     get_expected_identifiers,
     get_file_record,
@@ -103,13 +106,25 @@ def validate_data(
     # create present and implied identifier lists
     present_ids = get_present_identifiers(dataset, is_raw=is_raw)
     expected_ids = get_expected_identifiers(dataset, present_ids)
+    # FIXME: handle combination rows that have missing variables
     missing_ids = list(set(expected_ids) - set(present_ids))
+    # Filter out any missing IDs that are combination variables
+    joint_rows = get_joint_root_vars(dataset)
+    logger.debug("Joint rows: %s", joint_rows)
+    combo_rows = get_expected_combination_rows(dataset)
+    combo_variables = set()
+    for combo in combo_rows:
+        combo_variables.update(combo.variables)
+    missing_ids = [id for id in missing_ids if id.variable not in combo_variables]
+    
     logger.debug(
         "Found %d present id(s), %d expected id(s), %d missing id(s)",
         len(present_ids),
         len(expected_ids),
         len(missing_ids),
     )
+
+    
 
     # raise errors for missing identifiers without a no-data.txt
     for id in missing_ids:
@@ -138,11 +153,15 @@ def validate_data(
         if use_legacy_exceptions:
             no_data_file = "no-data.txt"
         else:
-            no_data_file = f"{id}_no-data.txt"
+            dir_files = os.listdir(missing_id_dir)
+            no_data_file = get_no_data_file(dir_files, id, joint_rows,logger)
 
-        if any([file == no_data_file for file in os.listdir(missing_id_dir)]):
+        
+
+        if no_data_file and os.path.isfile(os.path.join(missing_id_dir, no_data_file)):
             logger.debug("Skipping %s, no-data.txt found", str(id))
             continue
+
         pending.append(
             new_error_record(
                 logger,
@@ -156,9 +175,14 @@ def validate_data(
 
     sub_ses_run = get_unique_sub_ses_run(present_ids)
     logger.debug("Found %d unique subject/session/run combinations", len(sub_ses_run))
-
+    #FIXME: This code is way too nested, needs to be broken into functions
     # check conditions for combination rows
+    # throw error if for a given subject/session/run:
+    # there are multiple combination variables present
+    # or none of the combination variables are present
     combo_rows = get_expected_combination_rows(dataset)
+    # get all variables associated with joint rows
+        
     for combo in combo_rows:
         for sub, ses, run in sub_ses_run:
             present_combo_ids = [
@@ -210,6 +234,7 @@ def validate_data(
     logged_missing_ids = {}  # allow for multiple types of non-identifier-specific errors
 
     # loop over present identifiers (as Identifier objects)
+
     for id in present_ids:
         logger.debug("Checking identifier %s", str(id))
         # initialize error tracking for this directory if it doesn't exist
@@ -287,11 +312,20 @@ def validate_data(
             deviation_file = "deviation.txt"
             no_data_file = "no-data.txt"
         else:
+            # alright within each id store the combination variables
             deviation_file = f"{id}_deviation.txt"
             no_data_file = f"{id}_no-data.txt"
 
         has_deviation = deviation_file in dir_filenames
         has_no_data = no_data_file in dir_filenames
+        # in case of joint rows
+        if not has_deviation:
+            deviation_file = get_deviation_file(dir_filenames, id, joint_rows,logger)
+            has_deviation = True if deviation_file else False
+        if not has_no_data:
+            no_data_file = get_no_data_file(dir_filenames, id, joint_rows,logger)
+            has_no_data = True if no_data_file else False
+
 
         logger.debug("has_deviation=%s, has_no_data=%s", has_deviation, has_no_data)
         if has_deviation and has_no_data:
@@ -437,7 +471,7 @@ def validate_data(
             if use_legacy_exceptions:
                 expected_files = ["no-data.txt"]
             else:
-                expected_files = [f"{id}_no-data.txt"]
+                expected_files = [no_data_file]
         elif has_deviation:
             # expect at least 2 appropriately-named files
             # (deviation.txt and at least one other file)
@@ -454,6 +488,7 @@ def validate_data(
                 )
                 directory_has_errors = True
         else:  # normal case
+            # FIXME: help it determine combination/joint rows
             expected_files = [
                 os.path.basename(file) for file in get_expected_files(dataset, id)
             ]
@@ -467,6 +502,7 @@ def validate_data(
 
         # check for missing expected files
         n_missing = 0
+        unexpected_files = []
         for file in expected_files:
             if file not in dir_filenames:
                 pending.append(
@@ -485,9 +521,35 @@ def validate_data(
             directory_has_errors = True
 
         # check for unexpected file presence
+        # FIXME : this does not handle combination/joint variables yet
         n_unexpected = 0
+        unexpected_files = []
+
         for file in dir_filenames:
             if file not in expected_files:
+                unexpected_files.append(file)
+        logger.debug("Unexpected files before sibling check: %s", unexpected_files)
+        # FIXME too many nested loops, break this out or put in a function
+        if unexpected_files:
+            for jr in joint_rows:
+                if id.variable in jr.variables:
+                    for var in jr.variables:
+                        sibling_id = Identifier(
+                            id.subject, var, id.session, id.run, id.event
+                        )
+                        # check if sibling_id is in present_ids
+                        if sibling_id in present_ids:
+                            sibling_files = get_expected_files(dataset, sibling_id)
+                            # get the difference between unexpected_files and sibling_files
+                            logger.debug("Sibling files for ID %s: %s", sibling_id, sibling_files)
+                            for file in unexpected_files[:]:
+                                if file in sibling_files:
+                                    unexpected_files.remove(file)
+                        else: 
+                            logger.debug("Sibling ID %s not present", sibling_id)
+        logger.debug("Unexpected files after sibling check: %s", unexpected_files)        
+        if unexpected_files:
+            for file in unexpected_files:
                 pending.append(
                     new_error_record(
                         logger,

--- a/hallmonitor/hmutils.py
+++ b/hallmonitor/hmutils.py
@@ -296,6 +296,8 @@ class Identifier:
             s += " (encrypted)"
         if is_combination_var(dataset, self.variable):
             s += " (combination)"
+        if is_join_var(dataset, self.variable):
+            s += " (joint)"
         if self.is_missing:
             s += " (missing)"
         return s
@@ -682,6 +684,55 @@ def is_combination_var(dataset, variable):
 
 
 @cache_with_metadata()
+def is_join_var(dataset, variable):
+    """Returns bool for whether a variable is present in a joint row"""
+    dd_df = get_datadict(dataset)
+    dtype = dd_df[dd_df["variable"] == variable]["dataType"]
+    if dtype.empty:
+        raise ValueError(f"Variable {variable} not valid")
+    combos_df = dd_df[dd_df["dataType"] == "joint"]
+    for _, row in combos_df.iterrows():
+        prov = str(row["provenance"])
+        if "variables:" in prov:
+            vars = prov.removeprefix("variables:").strip()
+            vars = vars.replace('"', "")
+            vars = vars.split(",")
+            vars = [v.strip() for v in vars]
+            if variable in vars:
+                return True
+    return False
+
+
+@cache_with_metadata()
+def get_all_join_var(dataset,variable):
+    """Get all joint variable rows from the data dictionary
+
+    Args:
+        dataset (str): The path to the dataset directory.
+    Returns:
+        list of JointRow: A list of JointRow objects representing joint variable rows.
+    """
+    dd_df = get_datadict(dataset)
+    combo_row = dd_df.loc[dd_df["variable"] == variable]
+    combo_type = combo_row["dataType"]
+    if combo_type.empty:
+        raise ValueError(f"Variable {variable} not valid")
+    elif combo_type.iloc[0] != "joint":
+        raise ValueError(f"Variable {variable} is not a joint variable")
+    joint_vars = []
+
+    prov = str(combo_row["provenance"])
+    if "variables:" in prov:
+        vars = prov.removeprefix("variables:").strip()
+        vars = vars.replace('"', "")
+        vars = vars.split(",")
+        vars = [v.strip() for v in vars]
+        joint_vars = vars
+    return joint_vars
+
+
+
+@cache_with_metadata()
 def get_present_identifiers(dataset, is_raw=True):
     """
     Extracts and returns a list of present identifiers from a dataset directory, excluding combination variables.
@@ -806,10 +857,10 @@ def get_expected_identifiers(dataset, present_ids):
     for prov in visit_prov:
         variables = str(prov).split(",")
         variables = [v.strip() for v in variables]
-        # exclude combination variables
+        # exclude combination and joint variables
         for v in variables:
             try:
-                if get_variable_datatype(dataset, v) != "combination":
+                if get_variable_datatype(dataset, v) not in ["combination", "joint"]:
                     expected_vars.append(v)
             except ValueError:  # problematic variable in visit data
                 continue
@@ -822,12 +873,16 @@ def get_expected_identifiers(dataset, present_ids):
 
     return sorted(expected_ids)
 
-
-@dataclass
+# a row that takes a different variable and is only true if at least one var is present
+@dataclass(order=True)
 class CombinationRow:
     name: str
     variables: list[str]
-
+# a row that takes a different variable and is only true if all vars are present
+@dataclass(order=True)
+class JointRow:
+    name: str
+    variables: list[str]
 
 def get_expected_combination_rows(dataset) -> list[CombinationRow]:
     """
@@ -855,6 +910,121 @@ def get_expected_combination_rows(dataset) -> list[CombinationRow]:
 
     return sorted(expected_combos)
 
+def get_expected_joint_rows(dataset) -> list[JointRow]:
+    """
+    Extracts and returns a list of expected joint rows from the given dataset.
+
+    Args:
+        dataset (str): The dataset's base directory path.
+
+    Returns:
+        A list of JointRow objects, each representing a joint variable
+        and its associated variables as specified in the dataset's data dictionary.
+    """
+    dd_df = get_datadict(dataset)
+    joint_vars = dd_df[dd_df["dataType"] == "joint"]
+
+    expected_combos = []
+    # FIXME: duplicate of get_expected_combination_rows; refactor later
+    for _, row in joint_vars.iterrows():
+        prov = str(row["provenance"])
+        if prov.startswith("variables:"):
+            vars = prov.removeprefix("variables:").strip()
+            vars = vars.replace('"', "")
+            vars = vars.split(",")
+            vars = [v.strip() for v in vars]
+            expected_combos.append(JointRow(row["variable"], vars))
+
+    return sorted(expected_combos)
+
+
+def get_joint_root_vars(dataset) -> list[JointRow]:
+    """
+    Get all joint variable names from the data dictionary.
+
+    Args:
+        dataset (str): The path to the dataset directory.
+    Returns:
+        list of str: A list of joint variable names.
+    """
+    joint_rows = get_expected_joint_rows(dataset)
+    # turn it into a dict
+    jr_dict = {row.name: row for row in joint_rows}
+
+    combination_rows = get_expected_combination_rows(dataset)
+    cr_dict = {row.name: row for row in combination_rows}
+    for jr in joint_rows:
+        jr_vars = []
+        for jr_var in jr.variables:
+            if jr_var in cr_dict:
+                # expand combination row variables
+                jr_vars.extend(cr_dict[jr_var].variables)
+            elif jr_var in jr_dict:
+                # expand joint row variables
+                jr_vars.extend(jr_dict[jr_var].variables)
+            else:
+                jr_vars.append(jr_var)
+        jr.variables = jr_vars
+    return joint_rows
+
+
+def get_deviation_file(dir_filenames, identifier, joint_rows, logger):
+    """
+    Check if a folder contains a deviation.txt file.
+    returns deviation string if found, else None.
+
+    Args:
+        filename (str): The filename to check.
+        identifier (str): The identifier string to look for in the deviation file.
+        """
+    # check if any file even ends with deviation.txt
+    if not any(f.endswith("deviation.txt") for f in dir_filenames):
+        return None
+    if any(f == f"{identifier}_deviation.txt" for f in dir_filenames):
+        return f"{identifier}_deviation.txt"
+    for joint_row in joint_rows:
+            if identifier.variable in joint_row.variables:
+                logger.debug("Identifier %s is part of joint row %s", identifier, joint_row.name)
+                # check for deviation/no-data files for joint root variable
+                #joint_deviation_file = f"{joint_row.name}_deviation.txt"
+                #joint_no_data_file = f"{joint_row.name}_no-data.txt"
+                for var in joint_row.variables:
+                    joint_id = Identifier(
+                        identifier.subject, var, identifier.session, identifier.run, identifier.event
+                    )
+                    joint_deviation_file = f"{joint_id}_deviation.txt"
+                    if joint_deviation_file in dir_filenames:
+                        logger.debug("Found joint deviation file %s for identifier %s", joint_deviation_file, identifier)
+                        return joint_deviation_file
+    return None
+    
+def get_no_data_file(dir_filenames, identifier, joint_rows, logger):
+    """
+    Check if a folder contains a no-data.txt file.
+    returns no-data string if found, else None.
+
+    Args:
+        filename (str): The filename to check.
+        identifier (str): The identifier string to look for in the no-data file.
+        """
+    if not any(f.endswith("no-data.txt") for f in dir_filenames):
+        return None
+    if any(f == f"{identifier}_no-data.txt" for f in dir_filenames):
+        return f"{identifier}_no-data.txt"
+    for joint_row in joint_rows:
+            if identifier.variable in joint_row.variables:
+                logger.debug("Identifier %s is part of joint row %s", identifier, joint_row.name)
+                #joint_deviation_file = f"{joint_row.name}_deviation.txt"
+                #joint_no_data_file = f"{joint_row.name}_no-data.txt"
+                for var in joint_row.variables:
+                    joint_id = Identifier(
+                        identifier.subject, var, identifier.session, identifier.run, identifier.event
+                    )
+                    joint_no_data_file = f"{joint_id}_no-data.txt"
+                    if joint_no_data_file in dir_filenames:
+                        logger.debug("Found joint no-data file %s for identifier %s", joint_no_data_file, identifier)
+                        return joint_no_data_file
+    return None
 
 def get_unique_sub_ses_run(identifiers):
     """Get unique subject/session/run tuples from a list of identifiers.

--- a/hallmonitor/tests/unit/test_Identifier.py
+++ b/hallmonitor/tests/unit/test_Identifier.py
@@ -96,12 +96,15 @@ def test_identifier_to_detailed_str(identifier, mock_dataset):
         ) as mock_get_variable_datatype,
         mock.patch("hallmonitor.hmutils.is_combination_var") as mock_is_combination_var,
         mock.patch("hallmonitor.hmutils.is_variable_encrypted") as mock_is_encrypted,
+        mock.patch("hallmonitor.hmutils.is_join_var") as mock_is_join_var,
     ):
         datatype = "mockdtype"
         mock_get_variable_datatype.return_value = datatype
         mock_is_encrypted.return_value = False
+        mock_is_join_var.return_value = False  # or True, as needed
 
         # test with combination var
+        
         mock_is_combination_var.return_value = True
         detailed_str = identifier.to_detailed_str(mock_dataset)
         assert detailed_str == f"sub-001/all_eeg/s1_r1_e1 ({datatype}) (combination)"
@@ -110,3 +113,5 @@ def test_identifier_to_detailed_str(identifier, mock_dataset):
         mock_is_combination_var.return_value = False
         detailed_str = identifier.to_detailed_str(mock_dataset)
         assert detailed_str == f"sub-001/all_eeg/s1_r1_e1 ({datatype})"
+
+

--- a/hallmonitor/update_tracker.py
+++ b/hallmonitor/update_tracker.py
@@ -17,6 +17,7 @@ from hallmonitor.hmutils import (
     get_datadict,
     get_expected_combination_rows,
     get_new_redcaps,
+    get_expected_joint_rows,
     get_timestamp,
     get_variable_datatype,
     write_pending_errors,
@@ -223,7 +224,7 @@ def get_study_num(dataset):
     raise ValueError("Could not find study number")
 
 
-def fill_combination_columns(dataset: str, tracker_df: pd.DataFrame):
+def fill_combination_columns(dataset: str, logger: logging.Logger, tracker_df: pd.DataFrame):
     """
     Fill in combination columns by checking for the presence of one or more "child variables".
 
@@ -236,15 +237,13 @@ def fill_combination_columns(dataset: str, tracker_df: pd.DataFrame):
     combination_rows = get_expected_combination_rows(dataset)
 
     for combo in combination_rows:
+        logger.debug(f"Filling combination column: {combo.name} with children: {combo.variables}")
         combo_suffixes = get_allowed_suffixes(dataset, combo.name)
         for suffix in combo_suffixes:
             combo_col = f"{combo.name}_{suffix}"
             var_cols = pd.Index([f"{var}_{suffix}" for var in combo.variables])
             # some variables may not be valid for this suffix, skip them
             var_cols = var_cols[var_cols.isin(tracker_df.columns)]
-            print("[CUSTOM DEBUG] Filling combination column...")
-            print("var_cols:", var_cols, type(var_cols))
-            print("combo_col:", combo_col, type(combo_col))
             # we treat the combination column as an aggregator that is 1 if
             #   any of its "child variables" are truthy and 0 otherwise
             tracker_df[combo_col] = (tracker_df[var_cols].replace("0", 0).fillna(0) != 0).any(axis="columns").astype(int)
@@ -256,12 +255,13 @@ def fill_combination_columns(dataset: str, tracker_df: pd.DataFrame):
     return tracker_df
 
 
-def fill_status_data_columns(dataset: str, tracker_df: pd.DataFrame):
+def fill_status_data_columns(dataset: str, logger: logging.Logger, tracker_df: pd.DataFrame):
     """
     Fill in "status" and "data" columns based on their specified values.
 
     Args:
         dataset (str): The path to the dataset's base directory.
+        logger (logging.Logger): The logger instance for logging messages.
         tracker_df (pd.DataFrame): The dataset's central tracker.
     Returns:
         pd.DataFrame: The updated central tracker.
@@ -350,31 +350,67 @@ def fill_status_data_columns(dataset: str, tracker_df: pd.DataFrame):
                         rc for rc in redcaps if file.lower() in rc.lower() and ses in rc
                     ]
                     if len(matching_rc) == 0:
+                        logger.debug(f"Filling data column: {colname} based on file: {file} - no matching REDCap found, setting to 0")
                         tracker_df[colname] = 0
                         break
                     rc_df = pd.read_csv(matching_rc[0])
-                    common_subjects = tracker_df.index.intersection(rc_df["record_id"])
+                    common_subjects = tracker_df.index.intersection(rc_df["record_id"].apply(lambda x: get_parent_id(x)))
+                    logger.debug(f"Filling data column: {colname} based on file: {file} with {len(common_subjects)} common subjects")
+                    logger.debug(f"Subjects not in common: {tracker_df.index[~tracker_df.index.isin(common_subjects)].tolist()}")
                     tracker_df.loc[~tracker_df.index.isin(common_subjects), colname] = 0
 
     return tracker_df
 
-
-def get_child_id(parent_id: str, study_no: str) -> int | None:
+def fill_joint_columns(dataset: str, logger: logging.Logger, tracker_df: pd.DataFrame):
     """
-    Given a parent ID, extract and return the corresponding child ID.
+    Fill in joint columns by checking for the presence of all "child variables".
 
     Args:
-        parent_id (str): The parent ID string.
+        dataset (str): The path to the dataset's base directory.
+        tracker_df (pd.DataFrame): The dataset's central tracker.
+    Returns:
+        pd.DataFrame: The updated central tracker.
+    """
+    joint_rows = get_expected_joint_rows(dataset)
+
+    for joint in joint_rows:
+        logger.debug(f"Filling joint column: {joint.name} with variables: {joint.variables}")
+        joint_suffixes = get_allowed_suffixes(dataset, joint.name)
+        for suffix in joint_suffixes:
+            joint_col = f"{joint.name}_{suffix}"
+            var_cols = pd.Index([f"{var}_{suffix}" for var in joint.variables])
+            # some variables may not be valid for this suffix, skip them
+            var_cols = var_cols[var_cols.isin(tracker_df.columns)]
+            # we treat the joint column as an aggregator that is 1 if
+            #   all of its "child variables" are truthy and 0 otherwise
+            tracker_df[joint_col] = (tracker_df[var_cols].replace("0", 0).fillna(0) != 0).all(axis="columns").astype(int)
+
+            if (tracker_df[joint_col] == 0).all():
+                # if the joint column is all 0, we leave it blank
+                tracker_df[joint_col] = ""
+
+    return tracker_df
+
+
+
+def get_parent_id(child_id: str) -> int | None:
+    """
+    Given a child ID, extract and return the corresponding parent ID.
+
+    Args:
+        child_id (str): The child ID string.
         study_no (str): The two-digit study number.
 
     Returns:
-        int | None: The corresponding child ID as an integer, or None if no match is found.
+        int | None: The corresponding parent ID as an integer, or None if no match is found.
     """
-    child_id_match = re.search(study_no + r"([089])(\d{4})", str(parent_id))
-    if child_id_match is None:
+    child_id = str(child_id)
+    study_no = child_id[:2]
+    parent_id_match = re.search(study_no + r"([089])(\d{4})", str(child_id))
+    if parent_id_match is None:
         return None
-    child_id = study_no + "0" + child_id_match.group(2)
-    return int(child_id)
+    parent_id = study_no + "0" + parent_id_match.group(2)
+    return int(parent_id)
 
 #TODO Refactor tracker_df into some class or data structure to avoid passing it around so much
 
@@ -569,11 +605,8 @@ def main(
 
     tracker_df = get_central_tracker(dataset)
     # tracker_df = tracker_df.replace("0", 0)
-    proj_name = os.path.basename(os.path.normpath(dataset)).removesuffix("-dataset")
-    # FIXME FIXME FIXME DO NOT INCLUDE THIS IN PRODUCTION CODE
-    if "-" in proj_name:
-        proj_name = proj_name.split("-")[1]
-
+    # proj_name = os.path.basename(os.path.normpath(dataset)).removesuffix("-dataset")
+    proj_name = os.path.basename(os.path.normpath(dataset))
     logger.debug("Project name: %s", proj_name)
     data_tracker_file = os.path.join(
         dataset, "data-monitoring", f"central-tracker_{proj_name}.csv"
@@ -765,9 +798,8 @@ def main(
                 if child_id_match is not None:
                     child_id = int(study_no + "0" + child_id_match.group(1))
                     rc_subjects.append(child_id)
-                    logger.debug(
-                        "Child ID %s found for parent ID %s", str(child_id), str(id)
-                    )
+                    #FIXME only debug if necessary
+                    # logger.debug("Child ID %s found for parent ID %s", str(child_id), str(id))
         else:
             rc_subjects = rc_ids
         rc_subjects.sort()
@@ -984,11 +1016,16 @@ def main(
     for _, row in id_df.iterrows():
         tracker_df.loc[int(row["id"]), row["colname"]] = row["passed"]
 
+    #FIXME: If a joint row depends on a combination row it may not be filled correctly
+
     # fill in combination columns based on the values of their "child variables"
-    tracker_df = fill_combination_columns(dataset, tracker_df)
+    tracker_df = fill_combination_columns(dataset, logger, tracker_df)
+
+    # fill in joint columns based on the values of their "child variables"
+    tracker_df = fill_joint_columns(dataset, logger, tracker_df)
 
     # fill in "status"/"data" columns based on their specified values
-    tracker_df = fill_status_data_columns(dataset, tracker_df)
+    tracker_df = fill_status_data_columns(dataset, logger, tracker_df)
 
     # Last Check: Ensure no data exists for subjects who did not consent
     # check_consent_tracker(tracker_df, variables=["consent","assent"])

--- a/hallmonitor/update_tracker.py
+++ b/hallmonitor/update_tracker.py
@@ -570,6 +570,9 @@ def main(
     tracker_df = get_central_tracker(dataset)
     # tracker_df = tracker_df.replace("0", 0)
     proj_name = os.path.basename(os.path.normpath(dataset)).removesuffix("-dataset")
+    # FIXME FIXME FIXME DO NOT INCLUDE THIS IN PRODUCTION CODE
+    if "-" in proj_name:
+        proj_name = proj_name.split("-")[1]
 
     logger.debug("Project name: %s", proj_name)
     data_tracker_file = os.path.join(


### PR DESCRIPTION
Modified main to include read-study by creating joint dataype.
Joint Datatype: enables folders to contain multiple ids of the same type (e.g arrow_alert_psyschopy_s1_r1_e1, reading_ranger_psychopy_s1_r1_e1)
- Modified pending errors remove any joint folders to not throw errors for them.
- modified deviation and no_data to include the names of joint files as well

